### PR TITLE
update xml2json to fix npm install on Node >= 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,9 +1954,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
-      "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -2002,12 +2002,12 @@
       }
     },
     "node-expat": {
-      "version": "2.3.17",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.17.tgz",
-      "integrity": "sha512-mNTxY/GMiZGayqdKZXyf6lJR7OM1JqyL0EISjE4XF7Ov7+X4zJjmlnfxCi6Gml90IEOyiYBcyJg9MHDsDp6YHw==",
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.18.tgz",
+      "integrity": "sha512-9dIrDxXePa9HSn+hhlAg1wXkvqOjxefEbMclGxk2cEnq/Y3U7Qo5HNNqeo3fQ4bVmLhcdt3YN1TZy7WMZy4MHw==",
       "requires": {
-        "bindings": "^1.2.1",
-        "nan": "^2.10.0"
+        "bindings": "^1.5.0",
+        "nan": "^2.13.2"
       }
     },
     "normalize-package-data": {
@@ -2920,9 +2920,9 @@
       },
       "dependencies": {
         "hoek": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
         }
       }
     },
@@ -3115,13 +3115,13 @@
       "dev": true
     },
     "xml2json": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.11.2.tgz",
-      "integrity": "sha512-ZJpHpPOL0T5lOvAHMnWm59iQOPqNtam5t2TMUllWZ1k5Wm8L5YyvQnkeaVnRKCvDwY5EumqXWyOjjMdQVz272A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
+      "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
       "requires": {
         "hoek": "^4.2.1",
         "joi": "^13.1.2",
-        "node-expat": "^2.3.15"
+        "node-expat": "^2.3.18"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "minimist": "^1.2.0",
     "prettier": "^1.16.4",
     "source-map-support": "^0.5.12",
-    "xml2json": "^0.11.2"
+    "xml2json": "^0.12.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
I was unable to `npm install`, using Node 12 on Mac:

```
jrr@jrrmbp ~/r/m/cobertura-merge (master)> npm i

> node-expat@2.3.17 install /Users/jrr/repos/morneau/cobertura-merge/node_modules/node-expat
> node-gyp rebuild

  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmlparse.o
  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmltok.o
  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmlrole.o
  LIBTOOL-STATIC Release/libexpat.a
  CXX(target) Release/obj.target/node_expat/node-expat.o
In file included from ../node-expat.cc:1:
In file included from ../../nan/nan.h:2722:
../../nan/nan_object_wrap.h:24:25: error: no member named 'IsNearDeath' in 'Nan::Persistent<v8::Object,
      v8::NonCopyablePersistentTraits<v8::Object> >'
    assert(persistent().IsNearDeath());
           ~~~~~~~~~~~~ ^
(...)
```

Updating `xml2json` fixed it.